### PR TITLE
Fix: No more 'All Caps' in the thesis title

### DIFF
--- a/m_thesis_en/pethesis.sty
+++ b/m_thesis_en/pethesis.sty
@@ -99,7 +99,7 @@
 	      \thispagestyle{empty}%
         \null\vskip0.7in%
         \begin{center}
-                \large\uppercase\expandafter{\@title}
+                \large\expandafter{\@title}
         \end{center}
         \vspace{1.5in}
         \begin{center}
@@ -118,7 +118,7 @@
                 MASTER OF ENGINEERING %\uppercase\expandafter{\@whichend}
 
                 \vspace{20pt}
-                                \rm January 29th 2020\\
+                                \rm January 23rd 2023\\
 
         \end{center}
         \vfill


### PR DESCRIPTION
>Given this situation, I'm introducing RSL's internal rule about this - 
as shown below, let's NEVER use all caps for paper titles from now on.
(Always write "Paper Title" even in the full text, not "PAPER TITLE".)

